### PR TITLE
Fixed nvim fn input with <ESC>, <CR> and <C-c> with error or empty string then make whichkey with error.

### DIFF
--- a/lua/toyide/core/keymappings.lua
+++ b/lua/toyide/core/keymappings.lua
@@ -139,12 +139,13 @@ M.km_whichkey = {
     normal_mode = {
         ["<leader>wk"] = {
             origin = function()
-                local input_key = vim.fn.input "WhichKey: "
                 -- ignore <ESC> or other empty input to make errors.
-                if type(input_key) == "nil" or string.match(input_key, "^%s+$") == input_key then
-                    return
-                end
-                vim.cmd("WhichKey " .. input_key)
+                safe_input({ prompt = "WhichKey: ", }, function(input_key)
+                    if type(input_key) == "nil" or input_key == '' then
+                        return
+                    end
+                    vim.cmd("WhichKey " .. input_key)
+                end)
             end,
             desc = "which-key query lookup by input",
             opts = nil,


### PR DESCRIPTION
nvim vim.ui.input or vim.fn.input will occur error for whichkey cmd execute from input.

- When typing <C-c> during any time of input, it gives E5108: Error executing lua Keyboard interrupt.
- When typing <ESC> during any time of input, it stops user query and executes on_confirm(nil).
- When typing <CR> as first key of input implying an empty string as input, it behaves exactly like <Esc>.

So, we have to enhance the input details to handle <ESC> <C-c> and empty <CR> input.

reference:
https://github.com/neovim/neovim/issues/18144